### PR TITLE
Change CodeClimate test reporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,5 +30,4 @@ jobs:
           command: npm test
       - run:
           name: Upload Test Report to Code Climate
-          command: |
-             ./cc-test-reporter after-build -t lcov --exit-code $?
+          command: ./cc-test-reporter after-build -t lcov --exit-code $?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,18 @@ jobs:
           key: code-gov-web-{{ checksum "package.json" }}
           paths:
             - code-gov-web/node_modules
+      - run: 
+          name: Download CondeClimate Test Reporter
+          command: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+      - run: 
+          name: Make Test Reporter Executable
+          command: chmod +x ./cc-test-reporter
+      - run:
+          command: ./cc-test-reporter before-build
       - run:
           name: Run Tests
           command: npm test
       - run:
-          name: Install CodeClimate Test Reporter
-          command: npm install codeclimate-test-reporter
-      - run:
-          name: Run CodeClimate Test Reporter
-          command: codeclimate-test-reporter < coverage/lcov.info
+          name: Upload Test Report to Code Climate
+          command: |
+             ./cc-test-reporter after-build -t lcov --exit-code $?


### PR DESCRIPTION
# Why

The test reporter that was being used in our CircleCI build was on the path of being deprecated.

# What changed

Change CodeClimate test reporter - 0284416
- Removed old CodeClimate test reporter and added code to use their new version.