### PR TITLE
Remove the next three years because time has passed.

### DIFF
--- a/src/app/components/policy-guide/docs/capacity/capacity-introduction/capacity-introduction.template.html
+++ b/src/app/components/policy-guide/docs/capacity/capacity-introduction/capacity-introduction.template.html
@@ -1,6 +1,6 @@
 <h1>Introduction - Building Your Agency's Open Source Practice</h1>
 <p>
-<a rel="noopener" href="/#/policy-guide/policy/open-source">Section 5 of the Federal Source Code Policy</a> outlines an Open Source Pilot Program that requires the release of a portion of Federal source code over the next three years. This section of code.gov provides advice for agencies in satisfying the requirements of the pilot.
+<a rel="noopener" href="/#/policy-guide/policy/open-source">Section 5 of the Federal Source Code Policy</a> outlines an Open Source Pilot Program that requires the release of a portion of Federal source code over three years. This section of code.gov provides advice for agencies in satisfying the requirements of the pilot.
 </p>
 <p>The open source practice for the U.S. government is expected to rapidly evolve and become more sophisticated over the next several years, so the advice provided here will also evolve.</p>
 <p>In addition to the requirements outline in <a rel="noopener" href="/#/policy-guide/policy/open-source">Section 5</a> of the policy, <a rel="noopener" pageScroll [routerLink]="['/policy-guide/policy/implementation']" href="#roles-and-responsibilities">Section 7.1</a> of the policy discusses roles and responsibilities within agencies in meeting the requirements of the policy. Regarding the Open Source Pilot Program specifically, it notes that:</p>


### PR DESCRIPTION
### Why?

* We had one outstanding copy change necessary to accurately reflect the status of the site.

### What Changed?

*  Removed "the next" from the policy info introduction page.