### PR TITLE
Scroll down based on the offset of the header height.

### DIFF
--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -26,6 +26,10 @@ export class HomeComponent {
     );
   }
 
+  /**
+   * Get the offset of the app navigation header so we scroll down to the about
+   * section and the header is flush against the section.
+   */
   getAboutOffset() {
     return document.querySelector('.app-navigation').clientHeight;
   }

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -16,12 +16,17 @@ export class HomeComponent {
 
   constructor(
     public stateService: StateService,
-    private seoService: SeoService) {
+    private seoService: SeoService,
+  ) {
     this.stateService.set('section', 'home');
     this.seoService.setTitle('Code.gov', false);
     this.seoService.setMetaDescription(
       'Code.gov is a platform designed to improve access to the federal government’s ' +
       'custom-developed software.'
     );
+  }
+
+  getAboutOffset() {
+    return document.querySelector('.app-navigation').clientHeight;
   }
 }

--- a/src/app/components/home/home.template.html
+++ b/src/app/components/home/home.template.html
@@ -11,7 +11,7 @@
       <repos-search autofocus=true buttonClasses="button--transparent"></repos-search>
     </div>
   </div>
-  <a class="scroll-indicator" title="Scroll Down" pageScroll [pageScrollDuration]="250" [pageScrollOffset]="75" pageScrollTarget=".about" href="#"><i class="fa fa-angle-down"></i></a>
+  <a class="scroll-indicator" title="Scroll Down" pageScroll [pageScrollDuration]="250" [pageScrollOffset]="getAboutOffset()" pageScrollTarget=".about" href="#"><i class="fa fa-angle-down"></i></a>
 </section>
 <section id="about" class="about">
   <div class="usa-grid">


### PR DESCRIPTION
### Why?

* On mobile, when you click the scroll down button it would not scroll down enough

### What Changed?

* Scrolling to a static offset did not work because the header changes heights at different resolutions. We now grab the height from the DOM.