### PR TITLE
Show the agency properly on the search results page.

### DIFF
--- a/src/app/components/agency-list-item/agency-list-item.template.html
+++ b/src/app/components/agency-list-item/agency-list-item.template.html
@@ -1,5 +1,5 @@
 <a class="card card--focusable agency-list-item" routerLink="/explore-code/agencies/{{agency.id}}">
   <div class="icon">
-    <img [src]="getIcon">
+    <img [src]="getIcon()">
   </div><h3>{{ agency.name }}</h3>
 </a>

--- a/src/app/components/search-results/search-results.component.ts
+++ b/src/app/components/search-results/search-results.component.ts
@@ -157,7 +157,7 @@ export class SearchResultsComponent {
   filterLicenses(result) {
     const filteredLicenses = this.getFilteredValues('licenses');
 
-    if (!result.permissions.licenses || filteredLicenses.length === 0) {
+    if (!result.permissions || !result.permissions.licenses || filteredLicenses.length === 0) {
       return true;
     }
 
@@ -171,7 +171,7 @@ export class SearchResultsComponent {
   filterUsageTypes(result) {
     const filteredUsageTypes = this.getFilteredValues('usageTypes');
 
-    if (!result.permissions.usageType || filteredUsageTypes.length === 0) {
+    if (!result.permissions || !result.permissions.usageType || filteredUsageTypes.length === 0) {
       return true;
     }
 
@@ -193,6 +193,6 @@ export class SearchResultsComponent {
   }
 
   getLicenses() {
-    return uniq(compact(flatten(this.results.map(result => result.permissions.licenses ? result.permissions.licenses.map(license => license.name) : []))));
+    return uniq(compact(flatten(this.results.map(result => result.permissions && result.permissions.licenses ? result.permissions.licenses.map(license => license.name) : []))));
   }
 }


### PR DESCRIPTION
### Why?

* Any search that displays an agency will throw an error

### What Changed?

* Perform a number of checks to ensure no errors are thrown

Closes #366.