### PR TITLE
Add additional checks to make sure no errors are thrown.

### DIFF
--- a/src/app/components/explore-code/repo/repo.template.html
+++ b/src/app/components/explore-code/repo/repo.template.html
@@ -77,7 +77,7 @@
           </ng-template>
         </li>
         <li class="card repo-license usa-width-one-half">
-          <div *ngIf="repo.permissions.licenses[0] && repo.permissions.licenses[0].name | isdefined; then licenseBlock else noLicenseBlock"></div>
+          <div *ngIf="(repo.permissions | isdefined) && (repo.permissions.licenses | isdefined) && (repo.permissions.licenses[0] | isdefined) && (repo.permissions.licenses[0].name | isdefined); then licenseBlock else noLicenseBlock"></div>
           <ng-template #licenseBlock>
             <div class="card__icon">
 


### PR DESCRIPTION
### Why?

* Whenever a release didn't have licenses, the front end attempted to access it and would throw an error

### What Changed?

* Provided further protections against a license not existing.