### PR TITLE
Remove .git from https regular expression.

### DIFF
--- a/config/github-deploy/index.js
+++ b/config/github-deploy/index.js
@@ -1,7 +1,7 @@
 const execSync = require('child_process').execSync;
 const helpers = require('../helpers');
 
-const HTTPS_REPO_NAME_RE = /Push  URL: https:\/\/github\.com\/.*\/(.*)\.git/;
+const HTTPS_REPO_NAME_RE = /Push  URL: https:\/\/github\.com\/.*\/(.*)/;
 const SSH_REPO_NAME_RE = /Push\s*URL:\s*git@github\.com:.*\/(.*)\.git/;
 
 function getWebpackConfigModule() {


### PR DESCRIPTION
# Why

When using https URLs for pushing to Github repos an error would show up stating that the repo couldn't be found. This was due to an error in the regular expression used to match remote repo URLs

# What changed

- The .git suffix was removed from the regular expression used to match the repo URL.