### PR TITLE
Remove schema date format.

### DIFF
--- a/src/assets/schemas/2.0.0.json
+++ b/src/assets/schemas/2.0.0.json
@@ -258,17 +258,14 @@
             "properties": {
               "created": {
                 "type": "string",
-                "format": "date",
                 "description": "The date the release was created, in YYYY-MM-DD or ISO 8601 format."
               },
               "lastModified": {
                 "type": "string",
-                "format": "date",
                 "description": "The date the release was modified, in YYYY-MM-DD or ISO 8601 format."
               },
               "metadataLastUpdated": {
                 "type": "string",
-                "format": "date",
                 "description": "The date the metadata of the release was last updated, in YYYY-MM-DD or ISO 8601 format."
               }
             },


### PR DESCRIPTION
- Our schema updater sets empty dates to empty strings. This will make code.json fail when passed through the validator with unchanged date values. The short term solution is to remove the format check in the schema so that the validator accepts empty strings.