### PR TITLE
Add community templates

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+# Code of Conduct
+
+This Code of Conduct applies to Code.gov, its repositories, communications, events and anyone participating in the Code.gov community [link to about page]. Your use of Code.gov means you accept and agree to abide by this Code of Conduct, which we may revise periodically. You should review this page from time to time. 
+
+## What we expect
+
+We expect all visitors and contributors to Code.gov to have a safe and engaging experience that is beneficial to our community. Members of our community have a diverse set of experiences and skillsets. As you engage our community, please ensure you are:  
+
+- __Considerate__: as an open source community, what you do will affect others. Ensure what you do is in the best interest of the project, and community at large. 
+- __Collaborative__: the essences of open source is collaborative in nature. Attempt to honor the spirit of open source by working together before conflict.
+- __Patient__: Remember that open source is a culture change in government and while Code.gov is a testament to that change, change is occurring thanks to many in this community. Be patient if your question or issue is not answered right away. Many are juggling multiple duties. Contributing to open-source projects is often an after hours affair. 
+- __Be Mindful__: Be aware of your actions, others actions. Treat others with dignity and respect --the way you want to be treated. Be kind. 
+- __Using clear communication__: We don’t all speak the same language. Further, written, or typed words lack tone or body language to help interpret intent or meaning. If your words could have more than one meaning, take time to be clearer and always air on the side of being kind. 
+
+# What we won’t accept
+
+Users have a reasonable expectation to engage our site and community free from harassment. Harassment can include offensive verbal comments related to gender, age, sexual orientation, disability, physical appearance, race, religion, deliberate intimidation, disruption of talks or events. In short, harassment of any kind.
+
+Anything that is unlawful, objectionable, offensive, abusive, threatening, defamatory, obscene, hateful, inflammatory, profane, racially, sexually or religiously offensive.  
+
+# Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including those with decision-making authority, will not be tolerated.
+Anyone asked to stop unacceptable behavior is expected to comply immediately. If a community member engages in unacceptable behavior, the Code.gov team will take any action it deems appropriate, up to and including a temporary ban or permanent expulsion from the community without warning. This can include removal from email lists, blocked from social media accounts, listservs, events and repos.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,21 @@
-## Welcome!
+# Welcome!
 
 We're so glad you're thinking about contributing to a U.S. Government open source project! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
 
 We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
 
+## How to contribute to Code.gov
+
+- Report bugs and request features via [Github Issues](https://github.com/GSA/code-gov-api/issues).
+- Join the [mailing list](http://code.us15.list-manage.com/subscribe?u=57dec439b29289fc14396b8db&id=a317168ea7) and stay up to date with our latest news.
+- [Share your ideas](mailto://code@gsa.gov) for how to improve Code.gov. We're always open to suggestions.
+- Create a [Github pull request](https://help.github.com/articles/creating-a-pull-request/) with new functionality or fixing a bug.
+- Improve or create documentation for Code.gov.
+- Help us improve our unit and integrations tests.
+- Triage tickets and review patches triaging-tickets created by other users.
+
 ## Public domain
 
 As noted in [LICENSE](LICENSE.md), this project is in the worldwide public domain (in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/)).
 
-All contributions to this project will be released under the CC0
-dedication. By submitting a pull request, you are agreeing to comply
-with this waiver of copyright interest.
+All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+Your issue may already be reported!
+Please search on the [issue track](../) before creating one.
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Browser Name and version:
+* Operating System and version (desktop or mobile):
+* Link to your project:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+A similar PR may already be submitted!
+Please search among the [Pull request](../) before creating one.
+
+Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:
+
+For more information, see the `CONTRIBUTING` guide.
+
+
+**Summary**
+
+<!-- Summary of the PR -->
+
+This PR fixes/implements the following **bugs/features**
+
+* [ ] Bug 1
+* [ ] Bug 2
+* [ ] Feature 1
+* [ ] Feature 2
+* [ ] Breaking changes
+
+<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
+
+Explain the **motivation** for making this change. What existing problem does the pull request solve?
+
+<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
+
+**Test plan (required)**
+
+Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
+
+<!-- Make sure tests pass on both Travis and Circle CI. -->
+
+**Code formatting**
+
+<!-- See the simple style guide. -->
+
+**Closing issues**
+
+<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
+Fixes #


### PR DESCRIPTION
# Why

Part of our effort in Code.gov is to create and foster a great community. We feel these documents are quickly becoming a cornerstone in many projects.

# What changed

- Added Code_OF_CONDUCT.md - 0f0bac2
- Added ISSUE_TEMPLATE.md and PULL_REQUEST_TEMPLATE.md - c3b4e30
- Refactored CONTRIBUTING.md - 7ca0bff