### PR TITLE
Issue380 routing url with parentheses

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,6 +43,8 @@ import { StateService } from './services/state';
 import { StatusService } from './services/status';
 import { MonacoEditorService } from './components/monaco-editor';
 import { ElasticsearchTermService, LunrTermService, TermService } from './services/term';
+import { UrlSerializer } from '@angular/router';
+import { CustomUrlSerializer } from './serializers/custom-url-serializer';
 
 // Application wide providers
 const APP_PROVIDERS = [
@@ -61,6 +63,7 @@ const APP_PROVIDERS = [
   StateService,
   StatusService,
   { provide: TermService, useClass: LunrTermService },
+  { provide: UrlSerializer, useClass: CustomUrlSerializer }
 ];
 
 /**

--- a/src/app/serializers/custom-url-serializer/custom-url-serializer.spec.ts
+++ b/src/app/serializers/custom-url-serializer/custom-url-serializer.spec.ts
@@ -1,0 +1,189 @@
+import { APP_BASE_HREF, HashLocationStrategy, LocationStrategy } from '@angular/common';
+import { Component } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { DefaultUrlSerializer, Router, RouterModule, UrlSerializer, UrlTree } from '@angular/router';
+import { CustomUrlSerializer } from './custom-url-serializer';
+
+@Component({
+    selector: '',
+    template: `<a routerLink="{{url}}">test link</a>`
+})
+class TestRoutingWithFullUrlComponent {
+    private url: string;
+
+    setUrl(newUrl: string) {
+      this.url = newUrl;
+    }
+}
+
+
+/**
+ * Unit tests for CustomUrlSerializer including tests for 3 things:
+ * 1) CustomUrlSerializer.parse():
+ * The parse function converts a relative url into a UrlTree.
+ * 
+ * 2) CustomUrlSerializer.serialize():
+ * The serialize function converts a UrlTree to a relative url string.
+ * 
+ * 3) Usage of routerLink:
+ * routerLink, when used in a template, sets an href attribute on an 
+ * a tag based on an expression between double curly braces
+ */
+describe('CustomUrlSerializer', () => {
+  
+  // The url serializer created for this app that correctly encodes parentheses
+  let customUrlSerializer: CustomUrlSerializer;
+  
+  // The url serializer that comes with Angular 2 and doesn't encode parentheses 
+  let defaultUrlSerializer: DefaultUrlSerializer;
+
+  beforeEach(() => {
+      customUrlSerializer = new CustomUrlSerializer();
+      defaultUrlSerializer = new DefaultUrlSerializer();
+  });
+
+  describe('parse', () => {
+
+    describe('when a regular url without need for any special encoding/escaping is given', () => {
+      it("the serializer's parsing method does not escape anything ", () => {
+        
+        let url: string = "/explore-code/agencies/DOJ"
+        
+        let expected_url_segments: Object[] = [
+          {"path":"explore-code","parameters":{}},
+          {"path":"agencies","parameters":{}},
+          {"path":"DOJ","parameters":{}}
+        ];
+        
+        let actual_url_segments = customUrlSerializer.parse(url).root.children.primary.segments;
+        
+        // Compare the value of the url segments, not whether they're techncially the same object in memory
+        expect(JSON.stringify(actual_url_segments)).toEqual(JSON.stringify(expected_url_segments));
+
+      });
+    });
+
+    describe('when a url with escaped parentheses is used', () => {
+      it('the serializer parsed and unescaped correctly', () => {
+        
+        let url : string = "/explore-code/agencies/DOJ/repos/Better%20View%20Pane%20Args%20%28Drupal%20module%29";
+        
+        let expected : Array<Object> = [
+          {path:"explore-code",parameters:{}},
+          {path:"agencies",parameters:{}},
+          {path:"DOJ",parameters:{}},
+          {path:"repos",parameters:{}},
+          {path:"Better View Pane Args (Drupal module)",parameters:{}}
+        ];
+        
+        let actual = customUrlSerializer.parse(url).root.children.primary.segments;
+
+        expect(JSON.stringify(actual)).toEqual(JSON.stringify(expected));
+        
+      });
+    });
+
+    describe('when a url with unescaped spaces and parentheses is used', () => {
+      it('the serializer parsed correctly', () => {
+        
+        let url : string = "/explore-code/agencies/DOJ/repos/Better View Pane Args (Drupal module)";
+        
+        let expected : Array<Object> = [
+          {path:"explore-code",parameters:{}},
+          {path:"agencies",parameters:{}},
+          {path:"DOJ",parameters:{}},
+          {path:"repos",parameters:{}},
+          {path:"Better View Pane Args (Drupal module)",parameters:{}}
+        ];
+        
+        let actual = customUrlSerializer.parse(url).root.children.primary.segments;
+
+        expect(JSON.stringify(actual)).toEqual(JSON.stringify(expected));
+        
+      });
+    });
+
+  });
+  
+  
+  describe('serialize', () => {
+    describe("when a normal url tree without parentheses", () => {
+      it("returns the correct url", () => {
+        
+        let original_url : string = "/explore-code/agencies/NASA";
+        
+        let urlTree : UrlTree = defaultUrlSerializer.parse(original_url);
+        
+        let actual_url : string = customUrlSerializer.serialize(urlTree);
+        
+        /* we're basically checking if the customer url serializer
+         * gives the same results as the default url serializer
+         * when there are no parentheses present
+         */
+        expect(actual_url).toEqual(original_url);
+        
+      });
+    });
+    
+    describe("when a urlTree represnting a url with parenthese is given", () => {
+      it("the Custom Url Serializer should correctly serialize with escaping", () => {
+        
+        let original_url : string = "/explore-code/agencies/NASA/repos/Abaqus%20User%20Subroutine%20Verification%20%28abaverify%29";
+
+        let urlTree : UrlTree = defaultUrlSerializer.parse(original_url);
+
+        let actual_url : string = customUrlSerializer.serialize(urlTree);
+        
+        /*
+          We're basically checking to see if the serialize method correctly
+          returns the reverse of the parse method.  We should note that we
+          check if the parse method by itself is correct above.
+        */
+        expect(original_url).toEqual(actual_url);
+
+      });
+    });
+
+  });  
+  
+
+  describe('Custom Url Serializer integrated in a template', () => {
+    
+      let fixture: ComponentFixture<TestRoutingWithFullUrlComponent>;
+      let testComponent: TestRoutingWithFullUrlComponent;
+      
+      beforeEach(() => {
+          TestBed.configureTestingModule({
+              imports: [
+                RouterModule.forRoot([], { useHash: true })
+              ],
+              declarations: [TestRoutingWithFullUrlComponent],
+              providers: [
+                { provide: APP_BASE_HREF, useValue: "/" },
+                
+                { provide: LocationStrategy, useClass: HashLocationStrategy },
+                
+                // CustomUrlSerializer replaces UrlSerializer like in app.module.ts
+                { provide: UrlSerializer, useClass: CustomUrlSerializer }
+              ],
+          });
+          fixture = TestBed.createComponent(TestRoutingWithFullUrlComponent);
+          testComponent = fixture.componentInstance;
+      });
+
+      it('should set correct href when use unescaped url', () => {
+        
+          let original_url : string = "/explore-code/agencies/NASA/repos/Acoustic Propagation and Emulation Toolset (APET)";
+          testComponent.setUrl(original_url); 
+
+          fixture.detectChanges();
+
+          let actualHref = fixture.nativeElement.querySelector('a').href;
+
+          let expectedUrl = window.location.href + "#" + "/explore-code/agencies/NASA/repos/Acoustic%20Propagation%20and%20Emulation%20Toolset%20%28APET%29";
+
+          expect(actualHref).toEqual(expectedUrl);
+      });
+  });
+  
+});

--- a/src/app/serializers/custom-url-serializer/custom-url-serializer.ts
+++ b/src/app/serializers/custom-url-serializer/custom-url-serializer.ts
@@ -5,15 +5,24 @@ export class CustomUrlSerializer implements UrlSerializer {
     private _defaultUrlSerializer: DefaultUrlSerializer = new DefaultUrlSerializer();
 
     parse(url: string): UrlTree {
+        
+        /*
+            We, counter-intuitively, replace parentheses with their
+            escaped equivalent because the DefaultUrlSerializer
+            incorrectly stops parsing when it hits a parentheses.
+            
+            It does however correctly parse urls with 
+            escaped parentheses.
+        */
+        url = url.replace(/\(/g, '%28').replace(/\)/g, '%29');
+        
+        return this._defaultUrlSerializer.parse(url);
 
-       url = url.replace(/%28/g, '(').replace(/%29/g, ')');
-
-       return this._defaultUrlSerializer.parse(url);
     }
 
     serialize(tree: UrlTree): string {
-
-       return this._defaultUrlSerializer.serialize(tree).replace(/\(/g, '%28').replace(/\)/g, '%29');
+        
+        return this._defaultUrlSerializer.serialize(tree).replace(/\(/g, '%28').replace(/\)/g, '%29');
 
     }
 }

--- a/src/app/serializers/custom-url-serializer/custom-url-serializer.ts
+++ b/src/app/serializers/custom-url-serializer/custom-url-serializer.ts
@@ -1,0 +1,19 @@
+import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
+
+export class CustomUrlSerializer implements UrlSerializer {
+
+    private _defaultUrlSerializer: DefaultUrlSerializer = new DefaultUrlSerializer();
+
+    parse(url: string): UrlTree {
+
+       url = url.replace(/%28/g, '(').replace(/%29/g, ')');
+
+       return this._defaultUrlSerializer.parse(url);
+    }
+
+    serialize(tree: UrlTree): string {
+
+       return this._defaultUrlSerializer.serialize(tree).replace(/\(/g, '%28').replace(/\)/g, '%29');
+
+    }
+}

--- a/src/app/serializers/custom-url-serializer/index.ts
+++ b/src/app/serializers/custom-url-serializer/index.ts
@@ -1,0 +1,1 @@
+export * from './custom-url-serializer';


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Correctly route urls that includes parentheses.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
 Parentheses can appear in urls because repo ids can include parentheses.  Previously, the routing would break and nothing would appear.  See https://github.com/GSA/code-gov-web/issues/380 for more info.

**Test plan (required)**

I added custom-url-serializer.spec.ts, which tests the new serializer's parse and serialize methods as well as usage of routerLink when the new url serializer is provided.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #380 