### PR TITLE
Add git global user info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,11 @@ jobs:
           name: Install Dependencies
           command: npm install
       - run:
+        name: set-git-user-info
+        command: |
+          git config --global user.name "CodeDotGov"
+          git config --global user.email "code@gsa.gov"
+      - run:
           name: Deploy to Staging
           command: npm run federalist-deploy:stag
   deploy-production:
@@ -101,6 +106,11 @@ jobs:
       - run:
           name: Install Dependencies
           command: npm install
+      - run:
+        name: set-git-user-info
+        command: |
+          git config --global user.name "CodeDotGov"
+          git config --global user.email "code@gsa.gov"
       - run:
           name: Deploy to Production
           command: npm run federalist-deploy:prod  


### PR DESCRIPTION
**Summary**

Git user info was added to the build process:

- Set deploy staging git global user.name and user.email for CodeDotGov github user
- Set deploy prod git global user.name and user.email for CodeDotGov github user

A new deployment key with read/write privileges was added to the Github repo and the CircleCI project. These changes need to be tested by actually deploying to staging and production.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Federalist deployments to staging and production are failing because the git user has not been set. The `federalist-deploy:stag` and `federalist-deploy:prod` are just pushing the built project to specific git branches to be picked up by Federalist.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

- Merge these changes into master and have the CircleCI workflow for the project run and try to deploy to stanging.
- If deploying to staging succeeds then the same process has to be done for production.