### PR TITLE
Remove version npm script from the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "start": "npm run server:dev",
     "start:hmr": "npm run server:dev:hmr",
     "preversion": "npm test",
-    "version": "npm run build",
     "postversion": "git push && git push --tags",
     "postinstall": "typings install",
     "licenses": "license-checker --json --relativeLicensePath --out dependency_licenses.json",


### PR DESCRIPTION
**Summary**

Remove version npm script from the package.json file. This is not letting us use the default NPM version command.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

We want to use the npm version command to manage our app versions.

**Test plan (required)**
