### PR TITLE
Fixed typo in name of GNU General Public License

### DIFF
--- a/src/app/components/policy-guide/docs/open-source/open-source-licensing/open-source-licensing.template.html
+++ b/src/app/components/policy-guide/docs/open-source/open-source-licensing/open-source-licensing.template.html
@@ -65,7 +65,7 @@
     </li>
   </ol>
 </ol>
-<h4>GNU Public License (GPL)</h4>
+<h4>GNU General Public License (GPL)</h4>
 <ol>
   <li>
     <p>Some agencies that have used this license:</p>


### PR DESCRIPTION
Fixed the name of the "GNU General Public License." It was missing the word "General"

A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* Fixes a typo in the name of the GNU General Public License

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**
No tests required. Just fixing a typo

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**
Just fixing a typo. So not affecting code format

**Closing issues**
No open issues for this that I saw.