### PR TITLE
Added open in mail client functionality to email link within repo.com…

### DIFF
--- a/src/app/components/explore-code/repo/repo.component.html
+++ b/src/app/components/explore-code/repo/repo.component.html
@@ -66,7 +66,8 @@
             <span *ngIf="repo.contact?.email | isdefined">
               <li>
                 <i class="icon fa fa-envelope-o"></i>
-                {{repo.contact.email}}
+                <a href="mailto:{{repo.contact.email}}?Subject=Contribution%20Inquiry" target="_top">
+                  {{repo.contact.email}}</a>
               </li>
           </span>
 


### PR DESCRIPTION

Mail client opens with default subject of "Contribution Inquiry" and uses the  "_top" href tag attribute which opens the document in the full body of the browser window 

**Summary**

<!-- Summary of the PR -->

This PR adds the ability for a user to click the email address of the project owner which opens a new window with the subject line "Contribution Inquiry".

This PR fixes/implements the following **bugs/features**

* [x] Feature 1
Improves page interaction by allowing clickable email link and opening of user's native email client

Adding this feature makes it easier for a user to contact a project owner to request more information about the library/API/project.  The link opens in the user's default email client and eliminates the potential for the user to miscopy or mistype the project owner's email address.

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

npm start runs the webpack build and the following screenshots are taken from my localhost:2700 deployment:

<img width="995" alt="screen shot 2018-03-26 at 1 53 51 pm" src="https://user-images.githubusercontent.com/26234015/37927809-a8504ff6-3100-11e8-997f-b4d6a0fb42bd.png">

<img width="896" alt="screen shot 2018-03-26 at 1 54 14 pm" src="https://user-images.githubusercontent.com/26234015/37927828-af51eb2a-3100-11e8-9fee-9987b757c38d.png">

Fixes #491 