### PR TITLE
Updated schema 2.0.0 with schema used in API harvester

### DIFF
--- a/src/assets/schemas/2.0.0.json
+++ b/src/assets/schemas/2.0.0.json
@@ -33,7 +33,6 @@
     "agency": {
       "type": "string",
       "description": "The agency acronym for Clinger Cohen Act agency, as defined by the United States Government Manual."
-
     },
     "releases": {
       "type": "array",
@@ -55,9 +54,8 @@
           },
           "description": {
             "type": "string",
-            "description": "A one- or two-sentence description of the release."
+            "description": "A one or two sentence description of the release."
           },
-
           "permissions": {
             "type": "object",
             "properties": {
@@ -77,8 +75,7 @@
                     }
                   },
                   "additionalProperties": false
-                },
-                "additionalProperties": false
+                }
               },
               "usageType": {
                 "type": "string",
@@ -90,20 +87,17 @@
                   "exemptByNationalSecurity",
                   "exemptByAgencySystem",
                   "exemptByAgencyMission",
-                  "exemptByCIO",
-                  "exemptByPolicyDate"
+                  "exemptByCIO"
                 ],
                 "additionalProperties": false
               },
               "exemptionText": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": ["string", "null"],
                 "description": "If an exemption is listed in the 'usageType' field, this field should include a one- or two- sentence justification for the exemption used."
               }
             },
-            "required":"licenses"
+            "additionalProperties": false,
+            "required": ["licenses"]
           },
           "tags": {
             "type": "array",
@@ -111,7 +105,6 @@
               "type": "string",
               "description": "An array of keywords that will be helpful in discovering and searching for the release."
             }
-
           },
           "contact": {
             "type": "object",
@@ -136,8 +129,8 @@
                 "description": "A phone number for the point of contact for the release."
               }
             },
-            "required": "email",
-            "additionalProperties": false
+            "additionalProperties": false,
+            "required": ["email"]
           },
           "status": {
             "type": "string",
@@ -157,7 +150,7 @@
             "description": "A lowercase string with the name of the version control system that is being used for the release. For example, 'git'."
           },
           "repositoryURL": {
-            "type": ["string", "null"],
+            "type": "string",
             "format": "uri",
             "description": "The URL of the public release repository for open source repositories. This field is not required for repositories that are only available as government-wide reuse or are closed (pursuant to one of the exemptions)."
           },
@@ -205,10 +198,6 @@
                   "type": "string",
                   "format": "uri",
                   "description": "The URL where the code repository, project, library or release can be found."
-                },
-                "isGovernmentRepo": {
-                  "type": "boolean",
-                  "description": "Is the code repository owned or managed by a federal agency?"
                 }
               },
               "additionalProperties": false
@@ -229,7 +218,6 @@
                   "format": "uri",
                   "description": "The URL where the software can be found."
                 }
-
               },
               "additionalProperties": false
             }
@@ -258,14 +246,17 @@
             "properties": {
               "created": {
                 "type": "string",
+                "format": "date",
                 "description": "The date the release was created, in YYYY-MM-DD or ISO 8601 format."
               },
               "lastModified": {
                 "type": "string",
+                "format": "date",
                 "description": "The date the release was modified, in YYYY-MM-DD or ISO 8601 format."
               },
               "metadataLastUpdated": {
                 "type": "string",
+                "format": "date",
                 "description": "The date the metadata of the release was last updated, in YYYY-MM-DD or ISO 8601 format."
               }
             },


### PR DESCRIPTION
**Summary**

Updated schema 2.0 that is being used in the validator to be the same as the schema used in our harvesting and validating process in the API

This PR fixes/implements the following **bugs/features**

* [x] #529 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

The 2.0.0 schema was defining required fields incorrectly and creating validation errors for our users that were incorrect.

**Test plan (required)**

**Closing issues**

Closes #529 