### PR TITLE
Add usageType to premissions required fields

### DIFF
--- a/src/assets/schemas/2.0.0.json
+++ b/src/assets/schemas/2.0.0.json
@@ -97,7 +97,7 @@
               }
             },
             "additionalProperties": false,
-            "required": ["licenses"]
+            "required": ["licenses", "usageType"]
           },
           "tags": {
             "type": "array",


### PR DESCRIPTION
**Summary**

`usageType` field was missing from the required fields for .releases.permissions field. This was causing false validations.

This PR fixes/implements the following **bugs/features**

* [x] #557 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

`usageType` field was missing from the required fields for .releases.permissions field. This was causing false validations.

The schema had to be updated to reflect the intent of the documentation we've released and the validations made by the harvester.

**Test plan (required)**

No code was changed. Only the 2.0 schema was updated.

Visual test of validation working as intended:
![image](https://user-images.githubusercontent.com/1918027/39841155-e01b0af8-53af-11e8-9111-9efe8d06116e.png)

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Closes #557 