### PR TITLE
Updated help-wanted-card.template.html to show agency_id next to agency logo

### DIFF
--- a/src/app/components/help-wanted/card/help-wanted-card.template.html
+++ b/src/app/components/help-wanted/card/help-wanted-card.template.html
@@ -35,8 +35,8 @@
   <div class="agency-details">
     <img alt="" [src]="item.image" *ngIf="item.image"/>
     <span
-      *ngIf="item?.agency?.name"
+      *ngIf="item?.agency_id"
       class="help-wanted-agency-name"
-    >{{item?.agency?.name}}</span>
+    >{{item?.agency_id}}</span>
   </div>
 </div>


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] #493 - Agency Name did not appear next to the agency logo on the Help Wanted Search.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

This will make it a little bit easier for end users to be able to tell what Agency the `Help Wanted` task belongs to. 

**Test plan**

I cloned the repo, made sure I was on the proper node version (6.11.0 at time of PR according to `.nvmrc`), installed the node_modules, and ran the development server. After that, I updated a couple lines of code with conditional angular logic to show/hide the `<span class="help-wanted-agency-name">` tag if the `agency_id` is set on the `item` object that is passed into the `help-wanted-card.template.html` file.

I also - 
* Manually tested the code on my local machine
* Ran unit tests - 
```
Finished in 2.681 secs / 2.918 secs @ 21:38:28 GMT-0600 (MDT)

SUMMARY:
✔ 119 tests completed

=============================== Coverage summary ===============================
Statements   : 73.99% ( 711/961 )
Branches     : 29.57% ( 55/186 )
Functions    : 56.38% ( 137/243 )
Lines        : 72.77% ( 628/863 )
================================================================================
```
* Ran the end-to-end tests - `1 spec, 0 failures - Finished in 3.364 seconds`

Below are two examples of what the UI looks like.
<img width="842" alt="screen shot 2018-06-05 at 6 56 20 pm" src="https://user-images.githubusercontent.com/1751160/41015832-474bd8e2-6909-11e8-9d0d-64b67646540f.png">
<img width="846" alt="screen shot 2018-06-05 at 6 56 26 pm" src="https://user-images.githubusercontent.com/1751160/41015834-48e31d00-6909-11e8-8bd2-02fc457d9ecd.png">


**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

Fixes #493