### PR TITLE
Adding How to Inventory Code menu option under Federal Agencies

### DIFF
--- a/config/examples/code-dot-gov.json
+++ b/config/examples/code-dot-gov.json
@@ -30,6 +30,7 @@
         {
           "name": "federal agencies",
           "links": [
+            { "name": "How to Inventory Code", "url": "/#/policy-guide/docs/compliance/inventory-code" },
             { "name": "Tools", "url": "/#/policy-guide/docs/compliance/inventory-code/tools/validate-schema" },
             { "name": "Compliance Dashboard", "url": "/#/policy-guide/docs/compliance/dashboard"}
           ]


### PR DESCRIPTION
@jlow81 per our conversation yesterday, I'm adding the "How to Inventory Code" menu option as the first option on the Federal Agencies submenu list.  The menu option is hyperlinked to the Metadata Schema 2.0.0 requirements. 

See demo:
https://files.fm/u/6des9n7g#/view/how-to-inventory-code.png


@DanielJDufour or @froi please review PR. 

thanks,

Ricardo 