### PR TITLE
isGovernmentRepo boolean is a missing optional field from schema

### DIFF
--- a/src/assets/schemas/2.0.0.json
+++ b/src/assets/schemas/2.0.0.json
@@ -198,6 +198,10 @@
                   "type": "string",
                   "format": "uri",
                   "description": "The URL where the code repository, project, library or release can be found."
+                },
+                "isGovernmentRepo":{
+                  "type": "boolean",
+                  "description": "True or False. Is the code repository owned or managed by a federal agency"
                 }
               },
               "additionalProperties": false


### PR DESCRIPTION
The metadata schema 2.0.0 is missing the isGovernmentRepo boolean field on the relatedCode property.  

isGovernmentRepo: [boolean] True or False. Is the code repository owned or managed by a federal agency?

https://code.gov/#!/policy-guide/docs/compliance/inventory-code

We validated this with USDS when they are referencing their relatedCode.
![isgovernmentrepo](https://user-images.githubusercontent.com/2433138/46040107-70f1cb80-c0dd-11e8-8acd-ff0f60d22b06.png)

Please review syntax :-) 