### PR TITLE
Increase the height of the select tag

### DIFF
--- a/src/app/components/repos-search/repos-search.template.html
+++ b/src/app/components/repos-search/repos-search.template.html
@@ -16,7 +16,7 @@
   </div>
   <div class="browse">
     Or
-    <select (change)="onBrowseByEntityChange($event.target.value)" id="agencyList" aria-label="browse by agency">
+    <select (change)="onBrowseByEntityChange($event.target.value)" id="agencyList" aria-label="browse by agency" style="height: 25px">
       <option [textContent]="browse_by_text"></option>
       <option value="All">All</option>
       <option *ngFor="let entity of entities" [textContent]="entity.name" [value]="entity.acronym"></option>


### PR DESCRIPTION
Select tag in the code.gov page is small which would give a jarring experience to the user. 

Fix: The height of the select tag can be increased to give a better user experience.

Note: It is not good practice to embedded the style inline as I am not sure, the side effect of updating the value universally, So I updated inline. Please have a look into it and update accordingly if need.

Tested on: Chrome Browser, Mac OSx

Here is the snapshot:
**Before the change :**

![screenshot 10](https://user-images.githubusercontent.com/31539453/46762296-5847ff00-ccf4-11e8-9cf3-3be9170d097f.png)

**After the change 👍 **

![screenshot 7](https://user-images.githubusercontent.com/31539453/46762356-70b81980-ccf4-11e8-867b-c782b9012329.png)
