### PR TITLE
Replace project details metadata background with bottom border

### DIFF
--- a/src/app/components/explore-code/repo/repo.component.scss
+++ b/src/app/components/explore-code/repo/repo.component.scss
@@ -53,7 +53,7 @@
   margin: 1rem 0;
   padding: .5rem;
   width: 100%;
-  background-color: lighten( $brand-blue , 60%);
+  border-bottom: 1px lightgray solid;
 
   li,span.li {
     display: inline;


### PR DESCRIPTION
**Summary**

This PR resolves #675 by removing the project details metadata blue background with a gray bottom border.

**Test plan (required)**

The change has been tested on Windows but should be checked on another operating system with better formatting support.