### PR TITLE
665 link code of contact

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We're so glad you're thinking about contributing to a U.S. Government open sourc
 
 ## How to contribute to code-gov-web
 
-- We want to ensure a welcoming environment for all of our projects. Our staff follows this [Code of Conduct](https://github.com/GSA/code-gov-web/blob/master/CODE_OF_CONDUCT.md) and all contributors should do the same.
+- We want to ensure a welcoming environment for all of our projects. Our staff follows this [Code of Conduct](CODE_OF_CONDUCT.md) and all contributors should do the same.
 - Report bugs and request features via [Github Issues](https://github.com/GSA/code-gov-web/issues).
    - If you are not sure that the issue is related to the website you can [create the issue in our general repository](https://github.com/gsa/code-gov/issue/new): [code-gov](https://github.com/gsa/code-gov)
 - Join the [mailing list](http://code.us15.list-manage.com/subscribe?u=57dec439b29289fc14396b8db&id=a317168ea7) and stay up to date with our latest news.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,9 @@
 
 We're so glad you're thinking about contributing to a U.S. Government open source project! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
 
-We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
-
 ## How to contribute to code-gov-web
 
+- We want to ensure a welcoming environment for all of our projects. Our staff follows this [Code of Conduct](https://github.com/GSA/code-gov-web/blob/master/CODE_OF_CONDUCT.md) and all contributors should do the same.
 - Report bugs and request features via [Github Issues](https://github.com/GSA/code-gov-web/issues).
    - If you are not sure that the issue is related to the website you can [create the issue in our general repository](https://github.com/gsa/code-gov/issue/new): [code-gov](https://github.com/gsa/code-gov)
 - Join the [mailing list](http://code.us15.list-manage.com/subscribe?u=57dec439b29289fc14396b8db&id=a317168ea7) and stay up to date with our latest news.


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* Feature: #665 Link to Code of Conduct form Contributing - github

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Allow people wanting to contribute to easily reference the Code of Conduct from Contributing.md. Adding the reference to the code of conduct at the top of the list on Contributing. So it is the first item people will reference while preparing to contribute to the repository.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Once I pushed my changes to my forked repository, I clicked the reference to Contributing and then the new link to Code of Conduct. The Code of Conduct was displayed,

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #665